### PR TITLE
Upgrading to latest nyc-config-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -680,10 +680,13 @@
       }
     },
     "@istanbuljs/nyc-config-typescript": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-0.1.3.tgz",
-      "integrity": "sha512-EzRFg92bRSD1W/zeuNkeGwph0nkWf+pP2l/lYW4/5hav7RjKKBN5kV1Ix7Tvi0CMu3pC4Wi/U7rNisiJMR3ORg==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.1.tgz",
+      "integrity": "sha512-/gz6LgVpky205LuoOfwEZmnUtaSmdk0QIMcNFj9OvxhiMhPpKftMgZmGN7jNj7jR+lr8IB1Yks3QSSSNSxfoaQ==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2"
+      }
     },
     "@istanbuljs/schema": {
       "version": "0.1.2",
@@ -1003,9 +1006,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
-      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
+      "version": "14.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
+      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
       "dev": true
     },
     "@types/yargs": {
@@ -5731,9 +5734,9 @@
       "dev": true
     },
     "ts-loader": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.9.tgz",
-      "integrity": "sha512-rQd+iIfz5z4HSVzhhRFP4M2OQ0QmihilWWauYvvowBfnRvr4DW+gqA2om70xp/07EQj1qBkLMWobnXsgmWMbmg==",
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.11.tgz",
+      "integrity": "sha512-06X+mWA2JXoXJHYAesUUL4mHFYhnmyoCdQVMXofXF552Lzd4wNwSGg7unJpttqUP7ziaruM8d7u8LUB6I1sgzA==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.0",
@@ -6387,10 +6390,21 @@
       "dev": true
     },
     "zone.js": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz",
-      "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
-      "dev": true
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.3.tgz",
+      "integrity": "sha512-Y4hTHoh4VcxU5BDGAqEoOnOiyT254w6CiHtpQxAJUSMZPyVgdbKf+5R7Mwz6xsPhMIeBXk5rTopRZDpjssTCUg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
   "devDependencies": {
     "@angular/compiler": "^11.0.0",
     "@angular/core": "^11.0.0",
-    "@istanbuljs/nyc-config-typescript": "^0.1.3",
+    "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/jasmine": "^3.6.1",
-    "@types/node": "^14.14.6",
+    "@types/node": "^14.14.7",
     "cross-conf-env": "^1.2.1",
     "dev-norms": "^1.7.1",
     "env-cmd": "^10.1.0",
@@ -66,7 +66,7 @@
     "rimraf": "^3.0.2",
     "rxjs": "^6.6.3",
     "source-map-support": "^0.5.19",
-    "ts-loader": "^8.0.9",
+    "ts-loader": "^8.0.11",
     "ts-node": "^9.0.0",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
@@ -74,7 +74,7 @@
     "tslint-plugin-prettier": "^2.3.0",
     "tsutils": "^3.17.1",
     "typescript": "^4.0.2",
-    "zone.js": "^0.10.3"
+    "zone.js": "^0.11.3"
   },
   "peerDependencies": {
     "rxjs": "^6",
@@ -82,7 +82,7 @@
     "@angular/compiler": "^11",
     "typescript": "^4",
     "jasmine": ">= 3 <= 4",
-    "zone.js": "^0.10.3"
+    "zone.js": "^0.11.3"
   },
   "importSort": {
     ".ts, .tsx": {


### PR DESCRIPTION
# Feature/Change Description

Upgrading to latest nyc-config-typescript

_Challenge_: No code coverage info is generated
